### PR TITLE
Add working-directory input to generate-documentation-qmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 # New features
 
-* `pro/generate-documentation-qmd`: Added `workworking_directory` option. 
+* `pro/generate-documentation-qmd`: Added `working_directory` option. 
 
 # viash-actions v3.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# viash-actions v3.1.0
+
+# New features
+
+* `pro/generate-documentation-qmd`: Added `workworking_directory` option. 
+
 # viash-actions v3.0.0
 
 ## New features

--- a/pro/generate-documentation-qmd/README.md
+++ b/pro/generate-documentation-qmd/README.md
@@ -30,6 +30,12 @@ We recommend using a Linux or MacOS runner if possible.
 
 * `tools_version` - _optional_. Release of Viash tools to use. Will use the latest release by default. Ex: `main_build`
 
+* `working_directory` - _optional_. Folder where this action will be executed. Most useful when using
+`actions/checkout` with a different `path:`, as paths to files in the resulting qmd
+are generated relative to the working directory. For example: checking out a repository 
+with `path: "my_project"`, `input_dir: "my_project/src/"` and not using `working_directory`; will
+result in in paths that look like `my_project/src/...`. Using `path: "my_project"`, 
+`input_dir: "./src/"` and `working_directory: "my_project/"` will generate paths like `./src/...`.
 
 ## Examples
 

--- a/pro/generate-documentation-qmd/action.yml
+++ b/pro/generate-documentation-qmd/action.yml
@@ -89,7 +89,7 @@ runs:
           extra_args+=(--dest_path "${{ inputs.dest_path }}")
         fi
 
-        ${{ inputs.working_directory }}/viash_tools/target/docker/quarto/generate_documentation_qmd/generate_documentation_qmd \
+       viash_tools/target/docker/quarto/generate_documentation_qmd/generate_documentation_qmd \
           --input "${{ inputs.input_dir }}" "${extra_args[@]}" \
           --output "${{ inputs.output_dir }}" \
           --git_repo "${{ inputs.repository }}" \

--- a/pro/generate-documentation-qmd/action.yml
+++ b/pro/generate-documentation-qmd/action.yml
@@ -70,6 +70,14 @@ runs:
         token: ${{ inputs.viash_pro_token }}
         path: ${{ inputs.working_directory }}/viash_tools
         ref: ${{ steps.latestrelease.outputs.releasetag }}
+    - name: 'Test'
+      shell: bash
+      working-directory: ${{ inputs.working_directory }}
+      run: |
+        echo "tree"
+        tree
+        echo "${{ inputs.input_dir }}"
+        tree "${{ inputs.input_dir }}"
     - name: 'Generate quarto markdown files.'
       shell: bash
       id: generate-schemas

--- a/pro/generate-documentation-qmd/action.yml
+++ b/pro/generate-documentation-qmd/action.yml
@@ -5,7 +5,7 @@ description: >
 inputs:
   input_dir:
     required: false
-    description: 'Directory where the viash configs can be found.'
+    description: 'Directory inside the working directory where the viash configs can be found.'
     default: "."
   component_template:
     required: false
@@ -45,11 +45,16 @@ inputs:
       Release of Viash tools to use.
     required: false
     default: 'latest'
+  working_directory:
+    description: >
+      Folder where this action will be executed.
+    default: './'
 runs:
   using: 'composite'
   steps:
     - name: Get latest release
       shell: bash
+      working-directory: ${{ inputs.working_directory }}
       id: latestrelease
       run: |
         if [ "${{ inputs.tools_version }}" == "latest" ]; then
@@ -63,18 +68,12 @@ runs:
       with: 
         repository: viash-io/viash_tools
         token: ${{ inputs.viash_pro_token }}
-        path: viash_tools
+        path: ${{ inputs.working_directory }}/viash_tools
         ref: ${{ steps.latestrelease.outputs.releasetag }}
-    - uses: viash-io/viash-actions/ns-list@main
-      id: nslistcomponents
-      if: inputs.components
-      with:
-        src: ${{ inputs.components }}
-        format: "json"
-        platform: "nextflow"
     - name: 'Generate quarto markdown files.'
       shell: bash
       id: generate-schemas
+      working-directory: ${{ inputs.working_directory }}
       run: |
         if [ "${{ contains(fromJSON('[true, false]'), inputs.write_index) }}" == "true" ]; then
           echo "The value passed with the write_index property must be either 'true' or 'false'."
@@ -90,7 +89,7 @@ runs:
           extra_args+=(--dest_path "${{ inputs.dest_path }}")
         fi
 
-        viash_tools/target/docker/quarto/generate_documentation_qmd/generate_documentation_qmd \
+        ${{ inputs.working_directory }}/viash_tools/target/docker/quarto/generate_documentation_qmd/generate_documentation_qmd \
           --input "${{ inputs.input_dir }}" "${extra_args[@]}" \
           --output "${{ inputs.output_dir }}" \
           --git_repo "${{ inputs.repository }}" \

--- a/pro/generate-documentation-qmd/action.yml
+++ b/pro/generate-documentation-qmd/action.yml
@@ -89,7 +89,7 @@ runs:
           extra_args+=(--dest_path "${{ inputs.dest_path }}")
         fi
 
-       viash_tools/target/docker/quarto/generate_documentation_qmd/generate_documentation_qmd \
+        viash_tools/target/docker/quarto/generate_documentation_qmd/generate_documentation_qmd \
           --input "${{ inputs.input_dir }}" "${extra_args[@]}" \
           --output "${{ inputs.output_dir }}" \
           --git_repo "${{ inputs.repository }}" \

--- a/pro/generate-documentation-qmd/action.yml
+++ b/pro/generate-documentation-qmd/action.yml
@@ -47,7 +47,8 @@ inputs:
     default: 'latest'
   working_directory:
     description: >
-      Folder where this action will be executed.
+      Folder where this action will be executed. Most usefull when using
+      the `actions/checkout` with a different `path:`.
     default: './'
 runs:
   using: 'composite'
@@ -70,14 +71,6 @@ runs:
         token: ${{ inputs.viash_pro_token }}
         path: ${{ inputs.working_directory }}/viash_tools
         ref: ${{ steps.latestrelease.outputs.releasetag }}
-    - name: 'Test'
-      shell: bash
-      working-directory: ${{ inputs.working_directory }}
-      run: |
-        echo "tree"
-        tree
-        echo "${{ inputs.input_dir }}"
-        tree "${{ inputs.input_dir }}"
     - name: 'Generate quarto markdown files.'
       shell: bash
       id: generate-schemas

--- a/pro/generate-documentation-qmd/action.yml
+++ b/pro/generate-documentation-qmd/action.yml
@@ -47,15 +47,18 @@ inputs:
     default: 'latest'
   working_directory:
     description: >
-      Folder where this action will be executed. Most usefull when using
-      the `actions/checkout` with a different `path:`.
+      Folder where this action will be executed. Most useful when using
+      `actions/checkout` with a different `path:`, as paths to files in the resulting qmd
+      are generated relative to the working directory. For example: checking out a repository 
+      with `path: "my_project"`, `input_dir: "my_project/src/"` and not using `working_directory`; will
+      result in in paths that look like `my_project/src/...`. Using `path: "my_project"`, 
+      `input_dir: "./src/"` and `working_directory: "my_project/"` will generate paths like `./src/...`.
     default: './'
 runs:
   using: 'composite'
   steps:
     - name: Get latest release
       shell: bash
-      working-directory: ${{ inputs.working_directory }}
       id: latestrelease
       run: |
         if [ "${{ inputs.tools_version }}" == "latest" ]; then


### PR DESCRIPTION
According to https://github.com/actions/runner/blob/main/docs/adrs/0549-composite-run-steps.md#shell-and-working-directory, this is the solution to getting working-directory added to a custom composite action. The regular `working-directory` only works in workflows jobs where you have a `run:` property, so this does _not_ work:


```yaml
- uses: viash-io/viash-actions/pro/generate-documentation-qmd@add_working_dir
  working-directory: openpipelines
  with:
    input_dir: ./
    output_dir: ../website/components/
    dest_path: "{type}s/{namespace}/{name}.qmd"
    viash_pro_token: ${{ secrets.GTHB_PAT }}
    tools_version: main_build
```
