### PR TITLE
Use `path` and `parent` to detect a component's resources.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * `pro/generate-documentation-qmd`: Added `working_directory` option. 
 
+## Bug fixes
+
+* `project/detect-changed-components`: Use `path` and `parent` to detect a component's resources.
+
 # viash-actions v3.0.0
 
 ## New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ## Bug fixes
 
-* `project/detect-changed-components`: Use `path` and `parent` to detect a component's resources.
+* `project/detect-changed-components`: Refactor component resource detection.
 
 # viash-actions v3.0.0
 

--- a/project/detect-changed-components/action.yml
+++ b/project/detect-changed-components/action.yml
@@ -24,6 +24,37 @@ runs:
       separator: ";"
       diff_relative: true
 
+  # Note: a component's resources is detected using a jq statement. 
+  # Example usage of the jq statement:
+  #
+  # Input:
+  # functionality:
+  #   resources:
+  #     - type: python_script
+  #       path: script.py
+  #       parent: file:/home/rcannood/workspace/openproblems/openproblems-v2/src/label_projection/methods/knn/config.vsh.yaml
+  #     - type: file
+  #       path: file.txt
+  #       parent: file:///home/rcannood/workspace/openproblems/openproblems-v2/
+  #     - type: "file"
+  #       path: "resources_test/label_projection/pancreas"
+  #       parent: "file:///home/rcannood/workspace/openproblems/openproblems-v2/"
+  #   test_resources:
+  #     - type: "file"
+  #       path: "LICENSE"
+  #       parent: "file:///home/rcannood/workspace/openproblems/openproblems-v2/"
+  #     - type: "file"
+  #       text: "content"
+  #       dest: "foo.txt"
+  # info:
+  #   config: /home/rcannood/workspace/openproblems/openproblems-v2/src/label_projection/methods/knn/config.vsh.yaml
+  #
+  # Output:
+  # /home/rcannood/workspace/openproblems/openproblems-v2/src/label_projection/methods/knn/config.vsh.yaml
+  # /home/rcannood/workspace/openproblems/openproblems-v2/src/label_projection/methods/knn/script.py
+  # /home/rcannood/workspace/openproblems/openproblems-v2/file.txt
+  # /home/rcannood/workspace/openproblems/openproblems-v2/resources_test/label_projection/pancreas
+  # /home/rcannood/workspace/openproblems/openproblems-v2/LICENSE
   - name: Set matrix to only run tests for components that had their config or resources changed.
     id: filter
     shell: bash
@@ -52,12 +83,18 @@ runs:
         echo "Checking '$config_path'"
 
         # get the components resources
-        readarray -t resources < <(jq -cr '
-          (.info.config | capture("^(?<dir>.*\/)").dir) as $dir |
-          ([.info.config] +
-            ([.functionality.resources[].path?] | map($dir + .)) +
-            ([.functionality.test_resources[].path?] | map($dir + .)))[]
-        ' <<< "$component")
+        readarray -t resources < <(
+          jq -cr '
+          (
+            [.info.config] +
+            [
+              .functionality.resources[], .functionality.test_resources[]
+                | select(.path and .parent)
+                | (.parent | sub("^file:(//)?"; "") | sub("/[^/]*$"; "")) + "/" + .path
+            ]
+          )[]
+          ' <<< "$component"
+        )
         
         # check if resource is in the list of changed resources
         for resource_rel_path in "${resources[@]}"; do


### PR DESCRIPTION
This PR is in preparation for the project-relative files.

Currently, a component's resources are determined by adding the dir of the component to the path of the resource. To use the same approach with project-relative files, you'd have to do something like:

* If project-relative: project-dir + path
* else: config-dir + path

This PR implements an alternative path. It uses the `parent` value of the resource, which will contain a path to the project dir or a path to the config depending on whether it's project-relative or not.

Note, the `parent` value was meant to be an internal setting used for tracking where resources are located and was not meant to be returned by config view. If the viash-actions depends on this field, we'll have to make sure that the field never disappears from the `viash config view`.

This PR was tested in `openproblems-bio/openproblems-v2` and succeeded. → [link to run](https://github.com/openproblems-bio/openproblems-v2/actions/runs/4762499569/jobs/8464799930) ←