### PR TITLE
Add delete flags to sync commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# viash-actions unreleased
+
+## Bug fixes
+
+* `project/sync-and-cache`: Add `--delete` flag to sync commands so files removed from the remote source are also removed locally (PR #56).
+
 # viash-actions v6.7.3
 
 ## Minor changes

--- a/project/sync-and-cache/action.yml
+++ b/project/sync-and-cache/action.yml
@@ -173,14 +173,15 @@ runs:
             aws s3 sync \
             "$s3_path" \
             "$dest_path" \
-            --no-sign-request
+            --no-sign-request \
+            --delete
         }
         function sync_gs() {
           local gs_path="$1"
           local dest_path="$2"
           local orig_setting=`gcloud config get-value auth/disable_credentials`
           gcloud config set auth/disable_credentials true
-          gcloud storage rsync -r "$gs_path" "$dest_path"
+          gcloud storage rsync -r "$gs_path" "$dest_path" --delete-unmatched-destination-objects
           gcloud config set auth/disable_credentials $orig_setting
         }
 


### PR DESCRIPTION
Add flags to sync commands in `project/sync-and-cache` so that files that have been removed from the remote test resources and removed from the cached local copy after sync. This prevents old, stale files hanging around which may cause issues.